### PR TITLE
【バグ修正】New-MgSitePermission実行エラー

### DIFF
--- a/.github/workflows/daily_workflow.yml
+++ b/.github/workflows/daily_workflow.yml
@@ -207,8 +207,7 @@ jobs:
           function Invoke-WithRetry {
               param(
                   [scriptblock]$ScriptBlock,
-                  [int]$MaxRetries = 3,
-                  [int]$DelaySeconds = 5
+                  [int]$MaxRetries = 5
               )
               $retryCount = 0
               $success = $false
@@ -223,8 +222,9 @@ jobs:
                       if ($retryCount -ge $MaxRetries) {
                           throw "Command failed after $MaxRetries attempts."
                       } else {
-                          Write-Output "Retrying in $DelaySeconds seconds..."
-                          Start-Sleep -Seconds $DelaySeconds
+                          $delaySeconds = $retryCount * 5
+                          Write-Output "Retrying in $delaySeconds seconds..."
+                          Start-Sleep -Seconds $delaySeconds
                       }
                   }
               }

--- a/.github/workflows/manual_workflow.yml
+++ b/.github/workflows/manual_workflow.yml
@@ -213,8 +213,7 @@ jobs:
           function Invoke-WithRetry {
               param(
                   [scriptblock]$ScriptBlock,
-                  [int]$MaxRetries = 3,
-                  [int]$DelaySeconds = 5
+                  [int]$MaxRetries = 5
               )
               $retryCount = 0
               $success = $false
@@ -229,8 +228,9 @@ jobs:
                       if ($retryCount -ge $MaxRetries) {
                           throw "Command failed after $MaxRetries attempts."
                       } else {
-                          Write-Output "Retrying in $DelaySeconds seconds..."
-                          Start-Sleep -Seconds $DelaySeconds
+                          $delaySeconds = $retryCount * 5
+                          Write-Output "Retrying in $delaySeconds seconds..."
+                          Start-Sleep -Seconds $delaySeconds
                       }
                   }
               }

--- a/src/000_setup/05_Create-SharePointSite/Retry-NewMgSitePermission.ps1
+++ b/src/000_setup/05_Create-SharePointSite/Retry-NewMgSitePermission.ps1
@@ -1,0 +1,122 @@
+<#
+    .SYNOPSIS
+        New-MgSitePermissionを別ウィンドウで再実行するスクリプト
+
+    .DESCRIPTION
+        ※本スクリプトはCreate-SharepointSite.ps1から呼び出される
+        Create-SharepointSite.ps1でNew-MgSitePermissionが失敗した場合に、
+        別ウィンドウでNew-MgSitePermissionを再実行するスクリプト
+        
+        (背景)
+        以下のモジュールのバージョンが2.24.0時点ではCreate-SharepointSite.ps1が正常に動作していたが、
+        バージョンが更新されたことにより、New-MgSitePermissionが正常に動作しなくなった。
+        ・Microsoft.Graph.Sites
+        ・Microsoft.Graph.Authentication
+        ・Microsoft.Graph
+        
+        (対応)
+        New-MgSitePermissionが実行される前に、同一ウィンドウ内でGet-SPOSiteを実行した際にエラーが発生している状態であるため、
+        別ウィンドウでNew-MgSitePermissionを再実行することで本事象を回避する。
+
+    .PARAMETER siteId
+        [必須] SharePoint Online サイトID
+    
+    .PARAMETER applicationId
+        [必須] Entra ID アプリケーションのクライアントID
+
+    .PARAMETER displayName
+        [必須] Entra ID アプリケーション名
+    
+#>
+
+Param(
+    [Parameter(Mandatory=$true)]
+    [String]$siteId,
+
+    [Parameter(Mandatory=$true)]
+    [String]$applicationId,
+
+    [Parameter(Mandatory=$true)]
+    [String]$displayName
+)
+
+# 変数定義
+$date = (Get-Date).ToString("yyyyMMdd")
+$logFolder = ".\log"
+$logFile = "$logFolder\$date`_log.txt"
+$outputs = Get-Content -Path ".\outputs.json" | ConvertFrom-Json
+
+# 関数定義
+## ログ出力関数
+function Write-Log {
+    param (
+        [string]$Message,
+        [ValidateSet("Info", "Warning", "Error")]
+        [string]$Level = "Info"
+    )
+        
+    $timestamp = (Get-Date).ToString("yyyy-MM-dd HH:mm:ss")
+    switch ($Level) {
+        "Info" {
+            Write-Host "[INFO] $Message" -ForegroundColor White
+            $logMessage = "$timestamp - [INFO] $Message"
+        }
+        "Warning" {
+            Write-Host "[WARNING] $Message" -ForegroundColor Yellow
+            $logMessage = "$timestamp - [WARNING] $Message"
+        }
+        "Error" {
+            Write-Host "[ERROR] $Message" -ForegroundColor Red
+            $logMessage = "$timestamp - [ERROR] $Message"
+        }
+    }
+    $logMessage | Out-File -FilePath $logFile -Append
+}
+
+# ログフォルダが存在しない場合は作成
+if (!(Test-Path -Path $logFolder)) {
+    New-Item -ItemType Directory -Path $logFolder | Out-Null
+}
+
+Write-Log -Message "Start executing Retry-NewMgSitePermission.ps1"
+
+try {
+    Start-Sleep -Seconds 1
+    # Microsoft Graphに接続
+    Write-Log -Message "Connecting to Microsoft Graph."   
+    Connect-MgGraph -Scopes "Group.ReadWrite.All", "User.Read", "Application.ReadWrite.All", "Sites.Read.All", "Sites.FullControl.All"
+    # 接続に成功したかを判定
+    if ($? -ne $true) {
+        throw "Failed to connect to Microsoft Graph"
+    }
+    Write-Log -Message "Connected to Microsoft Graph successfully."
+    
+    $params = @{
+        roles = @("write") 
+        grantedToIdentities = @(
+            @{
+                application = @{
+                    id = $applicationId
+                    displayName = $displayName
+                }
+            }
+        )
+    }
+
+    Write-Log -Message "Granting the application permissions to the site."
+    New-MgSitePermission -SiteId $siteId -BodyParameter $params -ErrorAction Stop
+
+    Write-Log -Message "Writing updated data to outputs.json file."
+    # 更新されたデータをoutputs.jsonファイルに書き込む
+    $outputs.deployProgress."05" = "completed"
+    $outputs | ConvertTo-Json | Set-Content -Path ".\outputs.json"
+    
+    Write-Log -Message "Execution of Create-SharepointSite.ps1 & Retry-NewMgSitePermission.ps1 is complete."
+    Write-Log -Message "---------------------------------------------"
+    Start-Sleep -Seconds 3
+}
+catch{
+    $outputs.deployProgress."05" = "failed"
+    $outputs | ConvertTo-Json | Set-Content -Path ".\outputs.json"
+    throw
+}


### PR DESCRIPTION
## 概要  
- PowerShell モジュールの最新バージョン（2.26.1）において、`New-MgSitePermission` 実行時に発生するエラー回避の暫定対応の適用
- GitHub Actionsワークフロー内でのリトライ処理の変更

## 変更点  
- `Create-SharepointSite.ps1` にて `New-MgSitePermission` 実行時にエラーが発生した場合、Start-Process powershellによる別プロセスで `Retry-NewMgSitePermission.ps1` を実行し、リトライを行うように変更  
- `daily_workflow.yml` および `manual_workflow.yml` におけるリトライ回数を 3 回から 5 回に増加  
- リトライの待機時間を固定の 5 秒から、「5 秒 × 現在のリトライ回数」へ変更  

### 詳細  
- 以下のモジュールにおいて、バージョン 2.24.0 では `Create-SharepointSite.ps1` が正常に動作していたが、最新の 2.26.1 では スクリプト内の`New-MgSitePermission` 実行時にエラーが発生するようになった  
    - Microsoft.Graph.Sites  
    - Microsoft.Graph.Authentication  
    - Microsoft.Graph  
- バージョン 2.26.1 においては、`New-MgSitePermission` の処理を `Get-MgSite` とは別のプロセスで実行することで、エラーを回避できることを確認  

## 関連 Issue  
- Issue 番号: #9 

## 確認事項  
- [x] 既存機能への影響範囲を確認しました  
- [x] 修正内容が期待通り動作することを確認しました  
- [x] 他の機能への影響がないことを確認しました  
- [x] 関連ドキュメントを最新の内容に更新しました  

## 備考  

